### PR TITLE
Fixes unhandledpromiserejectionwarning in non promise methods

### DIFF
--- a/hooks.js
+++ b/hooks.js
@@ -208,7 +208,12 @@ class HooksPromise {
                 /**
                  * Get the target method response
                  */
-                let responsePromised = originalMethod.apply(self, passedArgs);
+                let responsePromised;
+                try {
+                    responsePromised = originalMethod.apply(self, passedArgs);
+                } catch (e) {
+                    responsePromised = Promise.reject(e);
+                }
 
                 /**
                  * Convert it to a Promise if it is not to be able to chain it

--- a/mocks/model.mock.js
+++ b/mocks/model.mock.js
@@ -9,6 +9,9 @@ module.exports = {
                 resolve('1234');
             }),
             saveReturnObject: () => Promise.resolve({ a: 123 }),
+            saveThrowError: () => {
+                throw new Error('Thrown Error');
+            },
         };
     },
 };

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -176,6 +176,14 @@ describe('hooks-promise', () => {
                     expect(check2).equal('myPreHookMethod2');
                 });
         });
+
+        it('should catch and reject thrown errors when the original method is not a promise', () => {
+            model.pre('saveThrowError', spies.preHook2);
+            return model.saveThrowError()
+                .catch((err) => {
+                    expect(err.message).equal('Thrown Error');
+                });
+        });
     });
 
     describe('post()', () => {


### PR DESCRIPTION
This PR addresses an issue that results in an `UnhandledPromiseRejectionWarning` that occurs if the original method is not a promise (or results in a promise) and throws an error.  In this scenario the error will be thrown when originalMethod.apply is called, but before it is converted to a promise, resulting in an `UnhandledPromiseRejectionWarning`, which will not bubble up to any catch higher up the stack.

I've also updated the tests to include this scenario. You can reproduce this issue by running the tests on the current production code without the changes I've added to hooks.js.  (Screenshot for reference).

Thanks in advance for taking a look at this and hopefully merging it into a new release. This is currently a problem in our production app, and I would prefer not to change our dependancies to a fork.

![screenshot6231](https://user-images.githubusercontent.com/12876929/59882461-e42c2380-9377-11e9-9a77-4b5d05aae87e.png)
